### PR TITLE
feat: :sparkles: Support inputting extensions with second field

### DIFF
--- a/src/components/ExtensionField/ExtensionField.styled.ts
+++ b/src/components/ExtensionField/ExtensionField.styled.ts
@@ -1,0 +1,12 @@
+import { InputBase } from '@mui/material'
+import { grey } from '@mui/material/colors'
+import { styled } from '@mui/material/styles'
+
+const Styled = {
+  ExtensionFieldSplitted: styled(InputBase)({
+    borderLeft: `1px solid ${grey[300]}`,
+    paddingLeft: 10
+  })
+}
+
+export { Styled }

--- a/src/components/ExtensionField/ExtensionField.tsx
+++ b/src/components/ExtensionField/ExtensionField.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { InputBaseProps } from '@mui/material'
+import { Styled } from './ExtensionField.styled'
+
+export type ExtensionFieldProps = InputBaseProps
+
+const ExtensionField = React.forwardRef(
+  (props: ExtensionFieldProps, propRef) => {
+    return (
+      <Styled.ExtensionFieldSplitted
+        placeholder="ext."
+        type="tel"
+        {...props}
+        inputRef={propRef}
+      />
+    )
+  }
+)
+
+export default ExtensionField

--- a/src/components/ExtensionField/ExtensionField.tsx
+++ b/src/components/ExtensionField/ExtensionField.tsx
@@ -10,6 +10,9 @@ const ExtensionField = React.forwardRef(
       <Styled.ExtensionFieldSplitted
         placeholder="ext."
         type="tel"
+        inputProps={{
+          'data-testId': 'ext-input'
+        }}
         {...props}
         inputRef={propRef}
       />

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -120,6 +120,7 @@ describe('components/MuiTelInput', () => {
         countryCode: 'FR',
         nationalNumber: '626',
         numberType: null,
+        extension: null,
         numberValue: '+33626',
         reason: 'input'
       })
@@ -212,6 +213,7 @@ describe('components/MuiTelInput', () => {
         countryCode: 'FR',
         nationalNumber: '626922631',
         numberType: null,
+        extension: null,
         numberValue: '+33626922631',
         reason: 'input'
       })
@@ -258,6 +260,7 @@ describe('components/MuiTelInput', () => {
         countryCode: 'BE',
         nationalNumber: '',
         numberType: null,
+        extension: null,
         numberValue: '+32',
         reason: 'country'
       })
@@ -272,6 +275,7 @@ describe('components/MuiTelInput', () => {
         countryCode: 'BE',
         nationalNumber: '',
         numberType: null,
+        extension: null,
         numberValue: '+32',
         reason: 'country'
       })
@@ -314,6 +318,7 @@ describe('components/MuiTelInput', () => {
         countryCallingCode: '33',
         countryCode: 'FR',
         nationalNumber: '626',
+        extension: null,
         numberType: null,
         numberValue: '+33626',
         reason: 'input'
@@ -329,6 +334,7 @@ describe('components/MuiTelInput', () => {
         countryCode: 'US',
         nationalNumber: '2133734253',
         numberType: 'FIXED_LINE_OR_MOBILE',
+        extension: null,
         numberValue: '+12133734253',
         reason: 'input'
       })

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -9,6 +9,7 @@ import {
   expectButtonIsFlagOf,
   expectButtonNotIsFlagOf,
   getButtonElement,
+  getExtensionInputElement,
   getInputElement,
   selectCountry,
   typeInInputElement
@@ -523,4 +524,49 @@ describe('components/MuiTelInput', () => {
   //   await user.copy()
   //   expect(callback).toHaveBeenCalledTimes(1)
   // })
+})
+
+describe('ExtensionField', () => {
+  it('should render if extensions are enabled', () => {
+    render(<MuiTelWrapper enableExtensionField />)
+    const extInputEl = getExtensionInputElement()
+
+    expect(extInputEl).toBeInTheDocument()
+  })
+
+  it('should not render if extensions are not enabled', () => {
+    render(<MuiTelWrapper />)
+
+    expect(getExtensionInputElement).toThrowError()
+  })
+
+  it('should initialize with the extension number if one is passed', () => {
+    const ext = '321'
+    const numVal = `+1 777 888 9999 ext. ${ext}`
+
+    render(<MuiTelWrapper enableExtensionField value={numVal} />)
+    const extInputEl = getExtensionInputElement()
+
+    expect(extInputEl.value).toBe(ext)
+  })
+
+  it('should call onChange with the extension reason and latest extension value', async () => {
+    const changeHandler = vi.fn(() => {})
+
+    render(<MuiTelWrapper enableExtensionField onChange={changeHandler} />)
+    const extInputEl = getExtensionInputElement()
+
+    const input = '323'
+    await userEvent.type(extInputEl, input, { delay: 1 })
+
+    expect(changeHandler).toHaveBeenLastCalledWith('', {
+      countryCallingCode: null,
+      countryCode: null,
+      nationalNumber: '',
+      extension: input,
+      numberType: null,
+      numberValue: null,
+      reason: 'extension'
+    })
+  })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,7 @@ const MuiTelInput = React.forwardRef(
   (props: MuiTelInputProps, propRef: MuiTelInputProps['ref']) => {
     const {
       forceCallingCode = false,
-      enableExtensions = false,
+      enableExtensionField = false,
       onlyCountries,
       excludedCountries,
       defaultCountry,
@@ -221,7 +221,7 @@ const MuiTelInput = React.forwardRef(
                 />
               </InputAdornment>
             ),
-            endAdornment: enableExtensions ? (
+            endAdornment: enableExtensionField ? (
               <InputAdornment position="end" sx={{ flexShrink: 1 }}>
                 <ExtensionField
                   ref={extensionInputRef}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ExtensionField from '@components/ExtensionField/ExtensionField'
 import FlagButton from '@components/FlagButton/FlagButton'
 import FlagsMenu from '@components/FlagsMenu/FlagsMenu'
 import {
@@ -44,6 +45,7 @@ const MuiTelInput = React.forwardRef(
   (props: MuiTelInputProps, propRef: MuiTelInputProps['ref']) => {
     const {
       forceCallingCode = false,
+      enableExtensions = false,
       onlyCountries,
       excludedCountries,
       defaultCountry,
@@ -66,6 +68,7 @@ const MuiTelInput = React.forwardRef(
       className,
       getFlagElement = getDefaultFlagElement,
       unknownFlagElement = defaultUnknownFlagElement,
+      ExtensionFieldProps,
       ...restTextFieldProps
     } = props
     const textFieldRef = React.useRef<HTMLDivElement>(null)
@@ -76,17 +79,25 @@ const MuiTelInput = React.forwardRef(
 
     useMismatchProps(props)
 
-    const { onInputChange, onCountryChange, inputRef, isoCode, inputValue } =
-      usePhoneDigits({
-        forceCallingCode,
-        defaultCountry: validDefaultCountry,
-        value: value ?? '',
-        onChange,
-        excludedCountries,
-        onlyCountries,
-        disableFormatting,
-        continents
-      })
+    const {
+      onInputChange,
+      onCountryChange,
+      onExtensionChange,
+      inputRef,
+      isoCode,
+      inputValue,
+      extensionValue,
+      extensionInputRef
+    } = usePhoneDigits({
+      forceCallingCode,
+      defaultCountry: validDefaultCountry,
+      value: value ?? '',
+      onChange,
+      excludedCountries,
+      onlyCountries,
+      disableFormatting,
+      continents
+    })
 
     const handleOpenFlagsMenu = (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -210,6 +221,20 @@ const MuiTelInput = React.forwardRef(
                 />
               </InputAdornment>
             ),
+            endAdornment: enableExtensions ? (
+              <InputAdornment position="end" sx={{ flexShrink: 1 }}>
+                <ExtensionField
+                  ref={extensionInputRef}
+                  value={extensionValue ?? ''}
+                  onChange={onExtensionChange}
+                  disabled={disabled}
+                  {...ExtensionFieldProps}
+                  className={`MuiTelInput-Extension-InputField ${
+                    ExtensionFieldProps?.className || ''
+                  }`}
+                />
+              </InputAdornment>
+            ) : undefined,
             ...InputProps
           }}
           {...restTextFieldProps}

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,4 +1,5 @@
 import { NumberType } from 'libphonenumber-js'
+import { ExtensionFieldProps } from '@components/ExtensionField/ExtensionField'
 import type { MuiTelInputContinent } from '@shared/constants/continents'
 import type { MuiTelInputCountry } from '@shared/constants/countries'
 import type { MenuProps } from '@mui/material/Menu'
@@ -11,7 +12,7 @@ type BaseTextFieldProps = Omit<
 
 export type { MuiTelInputContinent, MuiTelInputCountry }
 
-export type MuiTelInputReason = 'country' | 'input'
+export type MuiTelInputReason = 'country' | 'input' | 'extension'
 
 export type MuiTelInputFlagElement = React.ReactNode
 
@@ -32,6 +33,7 @@ export interface MuiTelInputInfo {
   countryCode: MuiTelInputCountry | null
   countryCallingCode: string | null
   nationalNumber: string | null
+  extension: string | null
   numberType: Exclude<NumberType, undefined> | null
   numberValue: string | null
   reason: MuiTelInputReason
@@ -62,4 +64,6 @@ export type MuiTelInputProps = BaseTextFieldProps &
     MenuProps?: Partial<MenuProps>
     getFlagElement?: GetFlagElement
     unknownFlagElement?: MuiTelInputFlagElement
+    enableExtensions?: boolean
+    ExtensionFieldProps?: ExtensionFieldProps
   }

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -64,6 +64,6 @@ export type MuiTelInputProps = BaseTextFieldProps &
     MenuProps?: Partial<MenuProps>
     getFlagElement?: GetFlagElement
     unknownFlagElement?: MuiTelInputFlagElement
-    enableExtensions?: boolean
+    enableExtensionField?: boolean
     ExtensionFieldProps?: ExtensionFieldProps
   }

--- a/src/shared/helpers/ext.ts
+++ b/src/shared/helpers/ext.ts
@@ -1,0 +1,5 @@
+export const isValidExtension = (input: string): boolean => {
+  const digitsAndDashRegEx = /^[0-9-]*$/
+
+  return !digitsAndDashRegEx.test(input)
+}

--- a/src/shared/helpers/ext.ts
+++ b/src/shared/helpers/ext.ts
@@ -1,5 +1,5 @@
 export const isValidExtension = (input: string): boolean => {
   const digitsAndDashRegEx = /^[0-9-]*$/
 
-  return !digitsAndDashRegEx.test(input)
+  return digitsAndDashRegEx.test(input)
 }

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -135,7 +135,7 @@ export default function usePhoneDigits({
       countryCallingCode: asYouTypeRef.current.getCallingCode() || null,
       countryCode: asYouTypeRef.current.getCountry() || null,
       nationalNumber: asYouTypeRef.current.getNationalNumber(),
-      extension: state.extensionValue,
+      extension: state.extensionValue || null,
       numberType: asYouTypeRef.current.getNumber()?.getType() ?? null,
       numberValue: asYouTypeRef.current.getNumberValue() || null,
       reason
@@ -280,6 +280,7 @@ export default function usePhoneDigits({
     const inputValueWithoutCallingCode = isoCode
       ? removeOccurrence(inputValue, `+${getCallingCodeOfCountry(isoCode)}`)
       : inputValue
+
     // replace the old calling code with the new one, keeping the rest of the number
     let newValue = `+${callingCode}${inputValueWithoutCallingCode}`
 
@@ -305,10 +306,8 @@ export default function usePhoneDigits({
   }
 
   const onExtensionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (isValidExtension(event.target.value)) {
-      // do not allow user to enter non digit or dash characters
-      return
-    }
+    // do not allow user to enter invalid characters
+    if (!isValidExtension(event.target.value)) return
 
     setState((prev) => {
       return { ...prev, extensionValue: event.target.value }

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -130,17 +130,20 @@ export default function usePhoneDigits({
 
   const [previousValue, setPreviousValue] = React.useState(value)
 
-  const buildOnChangeInfo = (reason: MuiTelInputReason): MuiTelInputInfo => {
-    return {
-      countryCallingCode: asYouTypeRef.current.getCallingCode() || null,
-      countryCode: asYouTypeRef.current.getCountry() || null,
-      nationalNumber: asYouTypeRef.current.getNationalNumber(),
-      extension: state.extensionValue || null,
-      numberType: asYouTypeRef.current.getNumber()?.getType() ?? null,
-      numberValue: asYouTypeRef.current.getNumberValue() || null,
-      reason
-    }
-  }
+  const buildOnChangeInfo = React.useCallback(
+    (reason: MuiTelInputReason): MuiTelInputInfo => {
+      return {
+        countryCallingCode: asYouTypeRef.current.getCallingCode() || null,
+        countryCode: asYouTypeRef.current.getCountry() || null,
+        nationalNumber: asYouTypeRef.current.getNationalNumber(),
+        extension: state.extensionValue || null,
+        numberType: asYouTypeRef.current.getNumber()?.getType() ?? null,
+        numberValue: asYouTypeRef.current.getNumberValue() || null,
+        reason
+      }
+    },
+    [state.extensionValue]
+  )
 
   const matchIsIsoCodeValid = (isoCode: MuiTelInputCountry | null) => {
     return (
@@ -261,13 +264,13 @@ export default function usePhoneDigits({
         extensionValue
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     defaultCountry,
     previousDefaultCountry,
     onChange,
     forceCallingCode,
-    disableFormatting
+    disableFormatting,
+    buildOnChangeInfo
   ])
 
   const onCountryChange = (newCountry: MuiTelInputCountry): void => {

--- a/src/shared/hooks/usePhoneDigits.ts
+++ b/src/shared/hooks/usePhoneDigits.ts
@@ -309,15 +309,20 @@ export default function usePhoneDigits({
   }
 
   const onExtensionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const extInputVal = event.target.value
+
     // do not allow user to enter invalid characters
-    if (!isValidExtension(event.target.value)) return
+    if (!isValidExtension(extInputVal)) return
 
     setState((prev) => {
-      return { ...prev, extensionValue: event.target.value }
+      return { ...prev, extensionValue: extInputVal }
     })
 
     const { inputValue } = state
-    onChange?.(inputValue, buildOnChangeInfo('extension'))
+    onChange?.(inputValue, {
+      ...buildOnChangeInfo('extension'),
+      extension: extInputVal
+    })
   }
 
   return {

--- a/src/testUtils/index.ts
+++ b/src/testUtils/index.ts
@@ -12,6 +12,10 @@ export function getInputElement(): HTMLInputElement {
   return screen.getByRole('textbox')
 }
 
+export function getExtensionInputElement(): HTMLInputElement {
+  return screen.getByTestId('ext-input')
+}
+
 export function getButtonElement(): HTMLButtonElement {
   return screen.getByRole('button')
 }


### PR DESCRIPTION
https://developers.google.com/style/phone-numbers#extensions
> To specify a phone extension, follow the phone number with the word extension, and then specify the extension number.



https://github.com/catamphetamine/libphonenumber-js
> Google's "As You Type" formatter does not support entering phone number extensions. If your project requires phone number extensions input then use a separate input field for that.

